### PR TITLE
Fix constraint creation task

### DIFF
--- a/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.0-clusterPrep-ScaleOut-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.0-clusterPrep-ScaleOut-RedHat.yml
@@ -161,7 +161,7 @@
 
         - name:                        "5.8 HANA Pacemaker Scaleout - Create constraints for pacemaker attribute resource on {{ primary_instance_name }}"
           ansible.builtin.shell: >
-                                       pcs constraint order fs_hana_shared_s1-clone then hana_nfs_s1_active-clone
+                                       pcs constraint order {{ item.fs_clone }} then {{ item.res_clone }}
           register:                    loc_attribute_hana_nfs_sites
           failed_when:                 false
           ignore_errors:               true


### PR DESCRIPTION
## Problem
Ordering constraint is only set up for one clone set, because of hardcoded values in the task.

## Solution
Modified task for the looping to work.