### PR TITLE
Control public access to AFS storage accounts at the sap_system level

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -96,6 +96,7 @@ module "common_infrastructure" {
   use_scalesets_for_deployment                  = var.use_scalesets_for_deployment
   dns_settings                                  = local.dns_settings
   enable_firewall_for_keyvaults_and_storage     = var.enable_firewall_for_keyvaults_and_storage
+  public_network_access_enabled                 = var.public_network_access_enabled
 
 }
 
@@ -142,6 +143,7 @@ module "hdb_node" {
   deployment                                    = var.deployment
   dns_settings                                  = local.dns_settings
   enable_firewall_for_keyvaults_and_storage     = var.enable_firewall_for_keyvaults_and_storage
+  public_network_access_enabled                 = var.public_network_access_enabled
   fencing_role_name                             = var.fencing_role_name
   hana_ANF_volumes                              = local.hana_ANF_volumes
   hanashared_id                                 = length(var.hanashared_id) > 0 ? (length(var.hanashared_id[0]) > 0 ? var.hanashared_id : []) : []

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -150,6 +150,12 @@ variable "enable_firewall_for_keyvaults_and_storage" {
                                                        type        = bool
                                                      }
 
+variable "public_network_access_enabled"        {
+                                                  description = "Boolean value indicating if public network access should be enabled for storage accounts (AFS shares like sid-share, hanashared). If not specified, the landscape setting will be used."
+                                                  default     = null
+                                                  type        = bool
+                                                }
+
 variable "encryption_at_host_enabled"           {
                                                   description = "Enables host encryption for sap vms"
                                                   default     = false

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/storage_accounts.tf
@@ -52,7 +52,11 @@ resource "azurerm_storage_account" "sapmnt" {
   shared_access_key_enabled            = var.infrastructure.shared_access_key_enabled_nfs
 
 
-  public_network_access_enabled        = try(var.landscape_tfstate.public_network_access_enabled, true)
+  #public_network_access_enabled        = try(var.landscape_tfstate.public_network_access_enabled, true)
+  public_network_access_enabled        = var.public_network_access_enabled != null ? (
+                                           var.public_network_access_enabled) : (
+                                           try(var.landscape_tfstate.public_network_access_enabled, true)
+                                         )
   tags                                 = var.tags
 
   network_rules {

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_global.tf
@@ -225,6 +225,12 @@ variable "enable_firewall_for_keyvaults_and_storage" {
                                                        type        = bool
                                                      }
 
+variable "public_network_access_enabled"         {
+                                                    description = "Boolean value indicating if public network access should be enabled for storage accounts (AFS shares). If not specified, the landscape setting will be used."
+                                                    default     = null
+                                                    type        = bool
+                                                 }
+
 #########################################################################################
 #                                                                                       #
 #  DNS settings                                                                         #

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/storage_accounts.tf
@@ -45,6 +45,11 @@ resource "azurerm_storage_account" "hanashared" {
   shared_access_key_enabled            = var.infrastructure.shared_access_key_enabled_nfs
   tags                                 = var.tags
 
+  public_network_access_enabled        = var.public_network_access_enabled != null ? (
+                                         var.public_network_access_enabled) : (
+                                         try(var.landscape_tfstate.public_network_access_enabled, true)
+                                       )
+
   network_rules {
                   default_action       = var.enable_firewall_for_keyvaults_and_storage ? "Deny" : "Allow"
                   bypass               = ["Metrics", "Logging", "AzureServices"]

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_global.tf
@@ -84,6 +84,12 @@ variable "enable_firewall_for_keyvaults_and_storage"    {
                                                           description = "Boolean value indicating if firewall should be enabled for key vaults and storage"
                                                           type        = bool
                                                         }
+
+variable "public_network_access_enabled"              {
+                                                          description = "Boolean value indicating if public network access should be enabled for storage accounts (AFS shares). If not specified, the landscape setting will be used."
+                                                          default     = null
+                                                          type        = bool
+                                                        }
 #########################################################################################
 #                                                                                       #
 #  DNS settings                                                                         #


### PR DESCRIPTION
## Problem
'public_network_access_enabled'  is 'true' by default and set at the sap_landscape level. Setting this to 'false' affects other resources as well, so we needed a more targeted approach.

## Solution
Therefore, we use the same variable at the sap_system level, directly targeting the storage accounts that might be created based on deployment types.

## Tests
Tested with non-HA HANA, DB2 and HANA scale-out deployments.

