### PR TITLE
Ignore source image updates

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-observer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-observer.tf
@@ -54,7 +54,10 @@ resource "azurerm_network_interface" "observer" {
 
 resource "azurerm_linux_virtual_machine" "observer" {
   lifecycle {
-    ignore_changes = [ tags ]
+    ignore_changes = [
+      tags,
+      source_image_id
+    ]
   }
 
   provider                             = azurerm.main


### PR DESCRIPTION
 This lifecycle block tells Terraform to ignore changes to the listed attributes on the VM resource, so plan/apply will not try to update or replace the VM if those attributes differ from state.

  - "tags": prevents Terraform from changing (or forcing updates for) tag diffs on the VM.
  - "source_image_id": prevent Terraform from attempting to update or recreate the VM when the image id changes (covers a custom image id).

  Consequence: external/manual changes to tags or to the VM image will be skipped by Terraform (changes must be managed outside Terraform or by removing the ignore).