### PR TITLE
Create mechanism to be able to add custom mount options to AFS shares

### DIFF
--- a/deploy/ansible/playbook_04_00_00_db_install.yaml
+++ b/deploy/ansible/playbook_04_00_00_db_install.yaml
@@ -309,6 +309,7 @@
             - { key: "ChallengeResponseAuthentication", value: "yes" }
 
         - name:                            Append root user to AllowUsers if used
+          become:                          true
           ansible.builtin.lineinfile:
             path:                          "/etc/ssh/sshd_config"
             regexp:                        '^AllowUsers (?!.*root.*)(.*)'

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.0-afs-mounts.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/2.6.0-afs-mounts.yaml
@@ -31,9 +31,17 @@
     - "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_SCS') }}"
     - "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_DB') }}"
 
+# The afs_mnt_options_default captures the baseline AFS mount options.
+# If afs_mnt_options has been pre-set (e.g. with additional hardening options),
+# it will be preserved. This allows consumers to extend mount options while
+# keeping the baseline available for computing deltas downstream.
+- name:                                "AFS Mount: Set the AFS mount options baseline"
+  ansible.builtin.set_fact:
+    afs_mnt_options_default:           'noresvport,vers=4,minorversion=1,sec=sys'
+
 - name:                                "AFS Mount: Set the NFSmount options"
   ansible.builtin.set_fact:
-    afs_mnt_options:                   'noresvport,vers=4,minorversion=1,sec=sys'
+    afs_mnt_options:                   "{{ afs_mnt_options | default(afs_mnt_options_default) }}"
 
 - name:                                "AFS Mount: Create list of all_sap_mounts to support"
   ansible.builtin.debug:
@@ -427,7 +435,7 @@
       'type':              'shared',
       'temppath':          'shared',
       'mount':             "{% if site | default('SITE1') == 'SITE1' %}{{ hana_shared_mountpoint[0] }}{% else %}{{ hana_shared_mountpoint[1] }}{% endif %}",
-      'opts':              'vers=4,minorversion=1,sec=sys',
+      'opts':              '{{ afs_mnt_options }}',
       'path':              '/hana/shared',
       'owner':             '{{ sidadm_uid }}',
       'permissions':       '0775',
@@ -450,7 +458,7 @@
       'type':              'shared',
       'temppath':          'shared',
       'mount':             "{{ hana_shared_mountpoint[0] }}",
-      'opts':              'vers=4,minorversion=1,sec=sys',
+      'opts':              '{{ afs_mnt_options }}',
       'path':              '/hana/shared',
       'owner':             '{{ sidadm_uid }}',
       'permissions':       '0775',

--- a/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.0-clusterPrep-ScaleOut-RedHat.yml
+++ b/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.0-clusterPrep-ScaleOut-RedHat.yml
@@ -16,12 +16,14 @@
 # +------------------------------------4--------------------------------------*/
 
 # We set this to prevent code overflow. Since pacemaker code for both AFS and ANF are the same barring NFS mount options, we parameterize this parameter.
+# Additional mount options (e.g. nodev,nosuid) are derived from afs_mnt_options
+# by computing the difference against afs_mnt_options_default and appending them.
 - name:                                "5.8 HANA Pacemaker Scaleout - NFS Compatibility - set mount options based on NFS source"
   ansible.builtin.set_fact:
-    nfs_mount_options:                 "{% if NFS_provider == 'ANF' %}defaults,rw,hard,rsize=262144,wsize=262144,proto=tcp,noatime,_netdev,nfsvers=4.1,lock,sec=sys{% else %}noresvport,defaults,rw,hard,proto=tcp,noatime,nfsvers=4.1,lock{% endif %}"
+    nfs_mount_options:                 "{% if NFS_provider == 'ANF' %}defaults,rw,hard,rsize=262144,wsize=262144,proto=tcp,noatime,_netdev,nfsvers=4.1,lock,sec=sys{% else %}noresvport,defaults,rw,hard,proto=tcp,noatime,nfsvers=4.1,lock{% set extras = afs_mnt_options.split(',') | difference(afs_mnt_options_default.split(',')) %}{% if extras %},{{ extras | join(',') }}{% endif %}{% endif %}"
     directory_path:                    "{% if NFS_provider == 'ANF' %}/shared{% else %}{% endif %}"
 
-  # Ref : https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability-scale-out-hsr-rhel?tabs=lb-portal#create-file-system-resources
+# Ref : https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability-scale-out-hsr-rhel?tabs=lb-portal#create-file-system-resources
 - name:                                "5.8 HANA Pacemaker Scaleout - Configure the ANF/AFS file system resources"
   when:
     - database_high_availability

--- a/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.0-clusterPrep-ScaleOut-Suse.yml
+++ b/deploy/ansible/roles-sap/5.8-hanadb-scaleout-pacemaker/tasks/5.8.4.0-clusterPrep-ScaleOut-Suse.yml
@@ -8,9 +8,11 @@
 # Ref: https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability
 # Ref: https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability-netapp-files-suse#create-file-system-resources
 
+# Additional mount options (e.g. nodev,nosuid) are derived from afs_mnt_options
+# by computing the difference against afs_mnt_options_default and appending them.
 - name:                            "5.8 HANA Pacemaker Scaleout - NFS Compatibility - set mount options based on NFS source"
   ansible.builtin.set_fact:
-    nfs_mount_options:             "{% if NFS_provider == 'ANF' %}bind,defaults,rw,hard,rsize=262144,wsize=262144,proto=tcp,noatime,_netdev,nfsvers=4.1,lock,sec=sys{% else %}bind,defaults,rw,hard,proto=tcp,noatime,nfsvers=4.1,lock{% endif %}"
+    nfs_mount_options:             "{% if NFS_provider == 'ANF' %}bind,defaults,rw,hard,rsize=262144,wsize=262144,proto=tcp,noatime,_netdev,nfsvers=4.1,lock,sec=sys{% else %}bind,defaults,rw,hard,proto=tcp,noatime,nfsvers=4.1,lock{% set extras = afs_mnt_options.split(',') | difference(afs_mnt_options_default.split(',')) %}{% if extras %},{{ extras | join(',') }}{% endif %}{% endif %}"
 
 - name:                            "5.8 HANA Pacemaker Scaleout - Scale-Out Cluster Compatibility - Fetch majority maker node name"
   ansible.builtin.set_fact:


### PR DESCRIPTION
Applies to `/sapmnt/<SID>` and `/hana/shared` in HA/non-HA scaleout deployments

## Problem
HANA non-HA/HA scale-out AFS shares `/sapmnt/<SID>` and `/hana/shared` (which can also be cluster-managed) had fixed options list.

## Solution
Used existing variable which either takes baseline values (from intermediary variable) or is baseline + what customers want to add.

## Tests
Tested with HANA HA scale-out deployment