### PR TITLE
Use remote ini files from BoM

### DIFF
--- a/deploy/ansible/roles-db/4.2.0-db2-install/tasks/main.yml
+++ b/deploy/ansible/roles-db/4.2.0-db2-install/tasks/main.yml
@@ -20,7 +20,7 @@
 - name:                                "SAP DB2 Install: Set BOM facts"
   ansible.builtin.set_fact:
     sap_inifile:                       "{{ bom_base_name }}-dbload-{{ ansible_hostname }}.params"
-    sap_inifile_template:              "dbload-inifile-param.j2"
+    sap_inifile_template:              "{{ (bom_base_name ~ bom_suffix ~ '-dbload-inifile-param.j2') if (use_remote_ini_files_from_bom | default(false)) else 'dbload-inifile-param.j2' }}"
     dir_params:                        "{{ tmp_directory }}/.{{ sap_sid | upper }}-params"
     mem_size:                          "{{ ansible_facts.memory_mb.real.total | int * 0.8 }}"
 
@@ -58,6 +58,31 @@
 - name:                                "DB2 Install"
   block:
 
+    - name:                            "DB2 Install - Include roles-sap/3.3.1-bom-utility role"
+      ansible.builtin.include_role:
+        name:                          roles-sap/3.3.1-bom-utility
+        tasks_from:                    bom-template
+      vars:
+        bom_name:                      "{{ bom_base_name }}"
+        task_prefix:                   "DB2 Install: "
+        always_upload_jinja_templates: false
+        db2_archive_path:              "{{ target_media_location }}/sapdb2_software"
+        db2_cd_package_exportcd:       "{{ target_media_location }}/CD_EXPORT/DATA_UNITS"
+        db2_cd_package_db2client:      "{{ db2_archive_path }}/db2client"
+        db2_cd_package_software:       "{{ db2_archive_path }}/db2server/LINUXX86_64"
+        db2_cd_package_kernel:         "{{ target_media_location }}/download_basket/"
+        sap_db_hostname:               "{{ virtual_host }}"
+        db2_encryption_algo_type:      "AES"
+        db2_ase_encryption_length:     "256"
+        db2_encryption_keystore_dir:   /db2/db2{{ db_sid | lower }}/keystore
+        db2_sslencryption_label:       "sap_db2{{ db_sid }}_{{ virtual_host }}_ssl_comm_000"
+        sap_scs_hostname:              "{{ custom_scs_virtual_hostname | default(hostvars[query('inventory_hostnames', '{{ sap_sid | upper }}_SCS') | first]['virtual_host'], true) }}"
+        sap_profile_dir:               "/sapmnt/{{ sap_sid | upper }}/profile"
+        tier:                          "db2S"
+        db2_memory:                    "{{ mem_size | int }}"
+        param_directory:               "{{ dir_params }}"
+      when:                            use_remote_ini_files_from_bom | default(false)
+
     - name:                            "DB2 Install: Template processing: Create ini file {{ sap_inifile }} from {{ sap_inifile_template }}"
       ansible.builtin.template:
         src:                           "{{ sap_inifile_template }}"
@@ -80,6 +105,7 @@
         tier:                          "db2S"
         db2_memory:                    "{{ mem_size | int }}"
         param_directory:               "{{ dir_params }}"
+      when:                            not (use_remote_ini_files_from_bom | default(false))
 
     - name:                            "DB2 Install: install variables"
       ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.0-db2_ha_install_primary.yml
@@ -23,7 +23,7 @@
     - name:                            "SAP DB2 Install: Set BOM facts"
       ansible.builtin.set_fact:
         sap_inifile:                   "{{ bom_base_name }}-dbload-{{ ansible_hostname }}.params"
-        sap_inifile_template:          "dbload-inifile-param.j2"
+        sap_inifile_template:          "{{ (bom_base_name ~ bom_suffix ~ '-dbload-inifile-param.j2') if (use_remote_ini_files_from_bom | default(false)) else 'dbload-inifile-param.j2' }}"
         dir_params:                    "{{ tmp_directory }}/.{{ sap_sid | upper }}-params"
         mem_size:                      "{{ ansible_facts.memory_mb.real.total | int * 0.8 }}"
 
@@ -81,6 +81,30 @@
           - "INIFILE:    {{ sap_inifile }}"
           - "mem_size:   {{ mem_size | int }}"
 
+    - name:                            "DB2 Install: Include roles-sap/3.3.1-bom-utility role"
+      ansible.builtin.include_role:
+        name:                          roles-sap/3.3.1-bom-utility
+        tasks_from:                    bom-template
+      vars:
+        bom_name:                      "{{ bom_base_name }}"
+        task_prefix:                   "DB2 Install: "
+        db2_archive_path:              "{{ target_media_location }}/sapdb2_software"
+        db2_cd_package_exportcd:       "{{ target_media_location }}/CD_EXPORT/DATA_UNITS"
+        db2_cd_package_db2client:      "{{ db2_archive_path }}/db2client"
+        db2_cd_package_software:       "{{ db2_archive_path }}/db2server/LINUXX86_64"
+        db2_cd_package_kernel:         "{{ target_media_location }}/download_basket/"
+        sap_db_hostname:               "{{ virtual_host }}"
+        db2_encryption_algo_type:      "AES"
+        db2_ase_encryption_length:     "256"
+        db2_encryption_keystore_dir:   /db2/db2{{ db_sid | lower }}/keystore
+        db2_sslencryption_label:       "sap_db2{{ db_sid }}_{{ virtual_host }}_ssl_comm_000"
+        sap_scs_hostname:              "{{ custom_scs_virtual_hostname | default(hostvars[query('inventory_hostnames', '{{ sap_sid | upper }}_SCS') | first]['virtual_host'], true) }}"
+        sap_profile_dir:               "/sapmnt/{{ sap_sid | upper }}/profile"
+        param_directory:               "{{ dir_params }}"
+        db2_memory:                    "{{ mem_size | int }}"
+        always_upload_jinja_templates: false
+      when:                            use_remote_ini_files_from_bom | default(false)
+
     - name:                            "DB2 Install: Template processing: Create ini file {{ sap_inifile }} from {{ sap_inifile_template }}"
       ansible.builtin.template:
         src:                           "{{ sap_inifile_template }}"
@@ -103,6 +127,7 @@
         param_directory:               "{{ dir_params }}"
         db2_memory:                    "{{ mem_size | int }}"
         always_upload_jinja_templates: false
+      when:                            not (use_remote_ini_files_from_bom | default(false))
 
     - name:                            "SAP DB2 install: variables"
       ansible.builtin.debug:

--- a/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.2-db2_ha_install_secondary.yml
+++ b/deploy/ansible/roles-db/4.2.1-db2-hainstall/tasks/4.2.1.2-db2_ha_install_secondary.yml
@@ -22,7 +22,7 @@
     - name:                            "SAP DB2 Install Secondary: Set BOM facts"
       ansible.builtin.set_fact:
         sap_inifile:                   "{{ bom_base_name }}-dbloadstandby-{{ ansible_hostname }}.params"
-        sap_inifile_template:          "dbloadstandby-inifile-param.j2"
+        sap_inifile_template:          "{{ (bom_base_name ~ bom_suffix ~ '-dbloadstandby-inifile-param.j2') if (use_remote_ini_files_from_bom | default(false)) else 'dbloadstandby-inifile-param.j2' }}"
         dir_params:                    "{{ tmp_directory }}/.{{ sap_sid | upper }}-params"
         mem_size:                      "{{ ansible_facts.memory_mb.real.total | int * 0.8 }}"
 
@@ -73,6 +73,30 @@
 - name:                                "DB2 Install - Secondary DB"
   block:
 
+    - name:                            "DB2 Install: Include roles-sap/3.3.1-bom-utility role"
+      ansible.builtin.include_role:
+        name:                          roles-sap/3.3.1-bom-utility
+        tasks_from:                    bom-template
+      vars:
+        bom_name:                      "{{ bom_base_name }}"
+        task_prefix:                   "DB2 Install: "
+        db2_archive_path:              "{{ target_media_location }}/sapdb2_software"
+        db2_cd_package_exportcd:       "{{ target_media_location }}/CD_EXPORT/DATA_UNITS"
+        db2_cd_package_db2client:      "{{ db2_archive_path }}/db2client"
+        db2_cd_package_software:       "{{ db2_archive_path }}/db2server/LINUXX86_64"
+        db2_cd_package_kernel:         "{{ target_media_location }}/download_basket/"
+        sap_db_hostname:               "{{ virtual_host }}"
+        db2_encryption_algo_type:      "AES"
+        db2_ase_encryption_length:     "256"
+        db2_encryption_keystore_dir:   /db2/db2{{ db_sid | lower }}/keystore
+        db2_sslencryption_label:       "sap_db2{{ db_sid }}_{{ virtual_host }}_ssl_comm_000"
+        sap_scs_hostname:              "{{ custom_scs_virtual_hostname | default(hostvars[query('inventory_hostnames', '{{ sap_sid | upper }}_SCS') | first]['virtual_host'], true) }}"
+        sap_profile_dir:               "/sapmnt/{{ sap_sid | upper }}/profile"
+        param_directory:               "{{ dir_params }}"
+        db2_memory:                    "{{ mem_size | int }}"
+        always_upload_jinja_templates: false
+      when:                            use_remote_ini_files_from_bom | default(false)
+
     - name:                            "DB2 Install: Template processing: Create ini file {{ sap_inifile }} from {{ sap_inifile_template }}"
       ansible.builtin.template:
         src:                           "{{ sap_inifile_template }}"
@@ -95,6 +119,7 @@
         param_directory:               "{{ dir_params }}"
         db2_memory:                    "{{ mem_size | int }}"
         always_upload_jinja_templates: false
+      when:                            not (use_remote_ini_files_from_bom | default(false))
 
 # +------------------------------------4--------------------------------------*/
 

--- a/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.0-scs-install/tasks/main.yaml
@@ -31,7 +31,7 @@
 - name:                                "SCS Install: Set BOM facts"
   ansible.builtin.set_fact:
     sap_inifile:                       "{{ bom_base_name }}-scs-{{ sid_to_be_deployed.sid | lower }}-{{ ansible_hostname }}.params"
-    sap_inifile_template:              "scs-inifile-param.j2"
+    sap_inifile_template:              "{{ (bom_base_name ~ bom_suffix ~ '-scs-inifile-param.j2') if (use_remote_ini_files_from_bom | default(false)) else 'scs-inifile-param.j2' }}"
     dir_params:                        "{{ tmp_directory }}/.{{ sid_to_be_deployed.sid | lower }}-params"
 
 - name:                                "SCS Install: -  Create directories"
@@ -120,6 +120,37 @@
         msg:                           "INSTALL:0002:Unable to find sapinst, please check that the installation media is mounted"
       when: not sapinst_found.stat.exists
 
+    - name:                            "SCS Install: Include roles-sap/3.3.1-bom-utility role"
+      ansible.builtin.include_role:
+        name:                          roles-sap/3.3.1-bom-utility
+        tasks_from:                    bom-template
+      vars:
+        task_prefix:                   "SCS Install: "
+        always_upload_jinja_templates: false
+        bom_name:                      "{{ bom_base_name }}{{ bom_suffix }}"
+        sap_cd_package_cd1:
+        sap_cd_package_cd2:
+        sap_cd_package_cd3:
+        sap_cd_package_cd4:
+        sap_cd_package_cd5:
+        sap_cd_package_hdbclient:
+        sap_ciInstanceNumber:
+        app_instance_number:
+        sap_ciDialogWPNumber:
+        sap_ciBtcWPNumber:
+        sap_installSAPHostAgent:
+        sap_profile_dir:
+        sap_scs_hostname:              "{{ scs_virtual_hostname }}"
+        sap_db_hostname:
+        sap_ciVirtualHostname:
+        sap_appVirtualHostname:
+        param_directory:               "{{ dir_params }}"
+        sap_sid:                       "{{ sid_to_be_deployed.sid }}"
+        scs_instance_number:           "{{ sid_to_be_deployed.ascs_inst_no }}"
+        sidadm_uid:                    "{{ sid_to_be_deployed.sidadm_uid }}"
+        hdb_instance_number:           "{{ db_instance_number }}"
+      when:                            use_remote_ini_files_from_bom | default(false)
+
     - name:                            "SCS Install: Template processing: Create ini file {{ sap_inifile }} from {{ sap_inifile_template }}"
       ansible.builtin.template:
         src:                           "{{ sap_inifile_template }}"
@@ -134,6 +165,7 @@
         sidadm_uid:                    "{{ sid_to_be_deployed.sidadm_uid }}"
         set_ascsInstallGateway:        "{{ installGateway | bool | lower }}"
         set_ascsInstallWebDispatcher:  "{{ ascsInstallWebDispatcher | default(false) | bool | lower }}"
+      when:                            not (use_remote_ini_files_from_bom | default(false))
 
     - name:                            "SCS Install: install variables"
       ansible.builtin.debug:

--- a/deploy/ansible/roles-sap/5.0.1-scs-ha-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.1-scs-ha-install/tasks/main.yaml
@@ -18,7 +18,7 @@
 - name:                                 "SCS HA Install: Set BOM facts"
   ansible.builtin.set_fact:
     sap_inifile:                        "{{ bom_base_name }}-scsha-{{ ansible_hostname }}.params"
-    sap_inifile_template:               "scsha-inifile-param.j2"
+    sap_inifile_template:               "{{ (bom_base_name ~ bom_suffix ~ '-scsha-inifile-param.j2') if (use_remote_ini_files_from_bom | default(false)) else 'scsha-inifile-param.j2' }}"
     dir_params:                         "{{ tmp_directory }}/.{{ sid_to_be_deployed.sid | lower }}-params"
 
 #   0x) Create hidden directory for parameter files
@@ -78,6 +78,34 @@
         msg:                           "INSTALL:0003:Unable to find sapinst, please check that the installation media is mounted"
       when: not sapinst_found.stat.exists
 
+    - name:                            "SCS HA Install: Register BoM templates"
+      ansible.builtin.include_role:
+        name:                          roles-sap/3.3.1-bom-utility
+        tasks_from:                    bom-template
+      vars:
+        task_prefix:                   "SCS HA Install: "
+        always_upload_jinja_templates: false
+        bom_name:                      "{{ bom_base_name }}{{ bom_suffix }}"
+        sap_cd_package_cd1:
+        sap_cd_package_cd2:
+        sap_cd_package_cd3:
+        sap_cd_package_cd4:
+        sap_cd_package_cd5:
+        sap_cd_package_hdbclient:
+        sap_ciInstanceNumber:
+        app_instance_number:
+        sap_ciDialogWPNumber:
+        sap_ciBtcWPNumber:
+        sap_installSAPHostAgent:
+        sap_profile_dir:
+        sap_scs_hostname:              "{{ scs_virtual_hostname }}"
+        sap_db_hostname:
+        sap_ciVirtualHostname:
+        sap_appVirtualHostname:
+        param_directory:               "{{ dir_params }}"
+        hdb_instance_number:           "{{ db_instance_number }}"
+      when:                            use_remote_ini_files_from_bom | default(false)
+
     - name:                            "SCS HA Install: Template processing - Create ini file {{ sap_inifile }} from {{ sap_inifile_template }}"
       ansible.builtin.template:
         src:                           "{{ sap_inifile_template }}"
@@ -89,6 +117,7 @@
         param_directory:               "{{ dir_params }}"
         set_ascsInstallGateway:        "{{ installGateway | bool | lower }}"
         set_ascsInstallWebDispatcher:  "{{ ascsInstallWebDispatcher | default(false) | bool | lower }}"
+      when:                            not (use_remote_ini_files_from_bom | default(false))
 
     - name:                            "SCS HA Install: check if installed"
       ansible.builtin.debug:

--- a/deploy/ansible/roles-sap/5.0.2-ers-ha-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.0.2-ers-ha-install/tasks/main.yaml
@@ -13,7 +13,7 @@
 - name:                                "ERS Install: Set BOM facts"
   ansible.builtin.set_fact:
     sap_inifile:                       "{{ bom_base_name }}-ers-{{ ansible_hostname }}.params"
-    sap_inifile_template:              "ers-inifile-param.j2"
+    sap_inifile_template:              "{{ (bom_base_name ~ bom_suffix ~ '-ers-inifile-param.j2') if (use_remote_ini_files_from_bom | default(false)) else 'ers-inifile-param.j2' }}"
     dir_params:                        "{{ tmp_directory }}/.{{ sid_to_be_deployed.sid | lower }}-params"
 
 #   0x) Create hidden directory for parameter files
@@ -72,6 +72,34 @@
         msg:                           "INSTALL:0004:Unable to find sapinst, please check that the installation media is mounted"
       when: not sapinst_found.stat.exists
 
+    - name:                            "ERS Install: Register BoM templates"
+      ansible.builtin.include_role:
+        name:                          roles-sap/3.3.1-bom-utility
+        tasks_from:                    bom-template
+      vars:
+        task_prefix:                   "ERS Install: "
+        always_upload_jinja_templates: false
+        bom_name:                      "{{ bom_base_name }}{{ bom_suffix }}"
+        sap_cd_package_cd1:
+        sap_cd_package_cd2:
+        sap_cd_package_cd3:
+        sap_cd_package_cd4:
+        sap_cd_package_cd5:
+        sap_cd_package_hdbclient:
+        sap_ciInstanceNumber:
+        app_instance_number:
+        sap_ciDialogWPNumber:
+        sap_ciBtcWPNumber:
+        sap_installSAPHostAgent:
+        sap_profile_dir:               "/sapmnt/{{ sid_to_be_deployed.sid | upper }}/profile"
+        sap_db_hostname:
+        sap_ciVirtualHostname:
+        sap_appVirtualHostname:
+        sap_scs_hostname:              "{{ scs_virtual_hostname }}"
+        param_directory:               "{{ dir_params }}"
+        hdb_instance_number:           "{{ db_instance_number }}"
+      when:                            use_remote_ini_files_from_bom | default(false)
+
     - name:                            "ERS Install: Template processing - Create ini file {{ sap_inifile }} from {{ sap_inifile_template }}"
       ansible.builtin.template:
         src:                           "{{ sap_inifile_template }}"
@@ -84,6 +112,7 @@
         param_directory:               "{{ dir_params }}"
         set_ascsInstallGateway:        "{{ installGateway | bool | lower }}"
         set_ascsInstallWebDispatcher:  "{{ ascsInstallWebDispatcher | default(false) | bool | lower }}"
+      when:                            not (use_remote_ini_files_from_bom | default(false))
 
     - name:                            "ERS Install: check if installed"
       ansible.builtin.debug:

--- a/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
@@ -43,7 +43,7 @@
 - name:                                "PAS Install: Set BOM facts"
   ansible.builtin.set_fact:
     sap_inifile:                       "{{ bom_base_name }}-pas-{{ sid_to_be_deployed.sid | lower }}-{{ ansible_hostname }}.params"
-    sap_inifile_template:              "pas-inifile-param.j2"
+    sap_inifile_template:              "{{ (bom_base_name ~ bom_suffix ~ '-pas-inifile-param.j2') if (use_remote_ini_files_from_bom | default(false)) else 'pas-inifile-param.j2' }}"
     dir_params:                        "{{ tmp_directory }}/.{{ sid_to_be_deployed.sid | lower }}-params"
     db_lb_virtual_host_HANA:           "{% if database_high_availability %}{{ sid_to_be_deployed.sid | lower }}{{ db_sid | lower }}db{{ db_instance_number }}cl.{{ sap_fqdn }}{% else %}{{ db_virtualhost_temp | default(hostvars[db_server_temp | first]['virtual_host'], true) }}{% endif %}"
     db_lb_virtual_host_AnyDB:          "{% if database_high_availability %}{{ sid_to_be_deployed.sid | lower }}{{ db_sid | lower }}db{{ db_instance_number }}cl.{{ sap_fqdn }}{% else %}{{ db_server_temp }}{% endif %}"
@@ -166,6 +166,38 @@
         msg:                           "INSTALL:0006:Unable to find sapinst, please check that the installation media is mounted"
       when: not sapinst_found.stat.exists
 
+    - name:                            "PAS Install: Include roles-sap/3.3.1-bom-utility role"
+      ansible.builtin.include_role:
+        name:                          roles-sap/3.3.1-bom-utility
+        tasks_from:                    bom-template
+      vars:
+        task_prefix:                   "PAS Install: "
+        always_upload_jinja_templates: false
+        bom_name:                      "{{ bom_base_name }}{{ bom_suffix }}"
+        sap_cd_package_hdbclient:      "{{ target_media_location }}/CD_HDBCLIENT/SAP_HANA_CLIENT"
+        sap_cd_package_cd1:            "{{ target_media_location }}/CD_EXPORT"
+        sap_cd_package_cd2:
+        sap_cd_package_cd3:
+        sap_cd_package_cd4:
+        sap_cd_package_cd5:
+        sap_ciInstanceNumber:          "{{ instance_number }}"
+        app_instance_number:
+        sap_ciDialogWPNumber:          12
+        sap_ciBtcWPNumber:             8
+        sap_installSAPHostAgent:       "false"
+        sap_profile_dir:               /sapmnt/{{ sid_to_be_deployed.sid | upper }}/profile
+        sap_scs_hostname:              "{{ custom_scs_virtual_hostname | default(scs_server, true) }}"
+        sap_db_hostname:               "{{ custom_db_virtual_hostname | default(db_lb_virtual_host, true) | first }}"
+        sap_ciVirtualHostname:         "{{ pas_virtual_hostname | default(virtual_host, true) }}"
+        sap_appVirtualHostname:
+        param_directory:               "{{ dir_params }}"
+        sap_sid:                       "{{ sid_to_be_deployed.sid }}"
+        scs_instance_number:           "{{ sid_to_be_deployed.ascs_inst_no }}"
+        sidadm_uid:                    "{{ sid_to_be_deployed.sidadm_uid }}"
+        virt_do_not_resolve_hostname:  "{{ custom_db_virtual_hostname | default(db_lb_virtual_host, true) }}"
+        hdb_instance_number:           "{{ db_instance_number }}"
+      when:                            use_remote_ini_files_from_bom | default(false)
+
     - name:                            "PAS Install: Template processing - Create ini file {{ sap_inifile }} from {{ sap_inifile_template }}"
       ansible.builtin.template:
         src:                           "{{ sap_inifile_template }}"
@@ -187,6 +219,7 @@
         sidadm_uid:                    "{{ sid_to_be_deployed.sidadm_uid }}"
         virt_do_not_resolve_hostname:  "{{ custom_db_virtual_hostname | default(db_lb_virtual_host, true) }}"
         db_schema:                     "{% if platform == 'HANA' %}{{ schema_name }}{% endif %}"
+      when:                            not (use_remote_ini_files_from_bom | default(false))
 
     - name:                            "PAS Install: register variables"
       ansible.builtin.set_fact:

--- a/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
@@ -41,7 +41,7 @@
 - name:                                "APP Install: Set BOM facts"
   ansible.builtin.set_fact:
     sap_inifile:                       "{{ bom_base_name }}-app-{{ sid_to_be_deployed.sid }}-{{ ansible_hostname }}.params"
-    sap_inifile_template:              "app-inifile-param.j2"
+    sap_inifile_template:              "{{ (bom_base_name ~ bom_suffix ~ '-app-inifile-param.j2') if (use_remote_ini_files_from_bom | default(false)) else 'app-inifile-param.j2' }}"
     dir_params:                        "{{ tmp_directory }}/.{{ sid_to_be_deployed.sid | upper }}-params"
     db_lb_virtual_host_HANA:           "{% if database_high_availability %}{{ sid_to_be_deployed.sid | lower }}{{ db_sid | lower }}db{{ db_instance_number }}cl{% else %}{{ db_virtualhost_temp | default(hostvars[db_server_temp | first]['virtual_host'], true) }}{% endif %}"
     db_lb_virtual_host_AnyDB:          "{% if database_high_availability %}{{ sid_to_be_deployed.sid | lower }}{{ db_sid | lower }}db{{ db_instance_number }}cl{% else %}{{ db_server_temp }}{% endif %}"
@@ -176,6 +176,37 @@
         msg:                           "INSTALL:0007:Unable to find sapinst, please check that the installation media is mounted"
       when: not sapinst_found.stat.exists
 
+    - name:                            "APP Install: Include roles-sap/3.3.1-bom-utility role"
+      ansible.builtin.include_role:
+        name:                          roles-sap/3.3.1-bom-utility
+        tasks_from:                    bom-template
+      vars:
+        task_prefix:                   "APP Install: "
+        always_upload_jinja_templates: false
+        bom_name:                      "{{ bom_base_name }}{{ bom_suffix }}"
+        sap_cd_package_hdbclient:      "{{ target_media_location }}/CD_HDBCLIENT/SAP_HANA_CLIENT"
+        sap_cd_package_cd1:            "{{ target_media_location }}/CD_EXPORT"
+        sap_cd_package_cd2:
+        sap_cd_package_cd3:
+        sap_cd_package_cd4:
+        sap_cd_package_cd5:
+        sap_ciInstanceNumber:          "{{ sid_to_be_deployed.ascs_inst_no }}"
+        app_instance_number:           "{{ sid_to_be_deployed.app_inst_no }}"
+        sap_ciDialogWPNumber:          12
+        sap_ciBtcWPNumber:             8
+        sap_installSAPHostAgent:       "false"
+        sap_profile_dir:               /sapmnt/{{ sid_to_be_deployed.sid | upper }}/profile
+        sap_scs_hostname:              "{{ custom_scs_virtual_hostname | default(scs_server, true) }}"
+        sap_db_hostname:               "{{ custom_db_virtual_hostname | default(db_lb_virtual_host, true) | first }}"
+        sap_ciVirtualHostname:         "{{ query('inventory_hostnames', '{{ sap_sid | upper }}_APP') | first }}"
+        sap_appVirtualHostname:        "{{ app_virtual_hostname }}"
+        param_directory:               "{{ dir_params }}"
+        sap_sid:                       "{{ sid_to_be_deployed.sid }}"
+        sidadm_uid:                    "{{ sid_to_be_deployed.sidadm_uid }}"
+        virt_do_not_resolve_hostname:  "{{ custom_db_virtual_hostname | default(db_lb_virtual_host, true) }}"
+        hdb_instance_number:           "{{ db_instance_number }}"
+      when:                            use_remote_ini_files_from_bom | default(false)
+
     - name:                            "APP Install: Template processing - Create ini file {{ sap_inifile }} from {{ sap_inifile_template }}"
       ansible.builtin.template:
         src:                           "{{ sap_inifile_template }}"
@@ -200,6 +231,7 @@
         sidadm_uid:                    "{{ sid_to_be_deployed.sidadm_uid }}"
         virt_do_not_resolve_hostname:  "{{ custom_db_virtual_hostname | default(db_lb_virtual_host, true) }}"
         hana_schema:                   "{{ schema_name | default('') }}"
+      when:                            not (use_remote_ini_files_from_bom | default(false))
 
 
     - name:                            "App Install: install variables"


### PR DESCRIPTION
## Problem
Microsoft's move towards local ini file templates results in incomplete DB2 HA and non-HA installations for us.

## Solution
Re-added old mechanism where relevant ini files are created from templates present in a given BoM. This way all the custom configurations that we need are implemented.

## Tests
DB2 ABAP and JAVA HA deployments
DB2 non-HA ABAP deployment